### PR TITLE
start method is not defined for Runnable object

### DIFF
--- a/Java Core/Java Concurrency.txt
+++ b/Java Core/Java Concurrency.txt
@@ -39,7 +39,7 @@ Concurrency
 
         MyRunnable r = new MyRunnable();
         Thread t = new Thread(r);
-        r.start();
+        t.start();
 
     b)
         class MyThread extends Thread {


### PR DESCRIPTION
The start method should be called on the Thread object that was created with the Runnable object not on the Runnable object itself